### PR TITLE
Вернул дату на первое место сортировки

### DIFF
--- a/Obsidian Time Kanban/main.js
+++ b/Obsidian Time Kanban/main.js
@@ -54,7 +54,7 @@ TKB.renderKanban = function(dv) {
         // Используем "цепочку" сравнений. Если результат не 0, возвращаем его.
         return (
             // 1. По дате (основной ключ).
-            (TKB.toDate(a.date)?.ts || 0) - (TKB.toDate(b.date)?.ts || 0) ||
+            (TKB.toDate(a.date)?.getTime() || 0) - (TKB.toDate(b.date)?.getTime() || 0) ||
             
             // 2. По статусу "important" (важные задачи всегда выше в своей группе).
             ((b.status?.includes('important') || false) - (a.status?.includes('important') || false)) ||


### PR DESCRIPTION
Здравствуйте! Вы совершенно правы, спасибо, что заметили эту неточность. В логике сортировки действительно была ошибка. Сравнение по дате не работало корректно, из-за чего задачи с указанным временем получали более высокий приоритет, чем задачи на более раннюю дату без времени.

Проблема заключалась в том, что для объекта даты JavaScript использовалось свойство .ts (которое есть у объектов дат в Dataview/Luxon), в то время как следовало использовать метод .getTime().

Я исправил это в файле [main.js](code-assist-path:c:\Coding\Obsidian\Obsidian Time Kanban\main.js). Теперь задачи будут сначала строго сортироваться по дате, и только для задач с одинаковой датой будет применяться дальнейшая сортировка по наличию времени и остальным параметрам.